### PR TITLE
Corrected invalid boolean values

### DIFF
--- a/ProceduralDynamics/Parts/DYJproceduralwingB9/part.cfg
+++ b/ProceduralDynamics/Parts/DYJproceduralwingB9/part.cfg
@@ -44,8 +44,8 @@ PART
 
     // --- winglet parameters ---
     // dragCoeff will override the maximum_drag value
-    dragCoeff = 0.2
-    deflectionLiftCoeff = 0.5
+    dragCoeff = 0.2						// deprecated	//	[WRN             ] PartLoader Warning: Variable dragCoeff not found in Part
+    deflectionLiftCoeff = 0.5				// deprecated	//	[WRN             ] PartLoader Warning: Variable deflectionLiftCoeff not found in Part
 
     MODULE
     {

--- a/ProceduralDynamics/Parts/procedural_ControlSurface_SH_4m/part.cfg
+++ b/ProceduralDynamics/Parts/procedural_ControlSurface_SH_4m/part.cfg
@@ -50,7 +50,7 @@ PART
         doNotParticipateInParentSnapping = true
         isWing = false
         isCtrlSrf = true
-        relativeThicknessScaling = false;
+        relativeThicknessScaling = false	//	";"			//	[ERR             ] Invalid boolean value
     }
 
     MODULE


### PR DESCRIPTION
no ";" at eol

Note: ProceduralwingBac9
dragCoeff and deflectionLiftCoeff are deprecated.
Since B9 does support 1.x at the moment I haven't excluded these
variables.
